### PR TITLE
Update domain.conf to fix error 502

### DIFF
--- a/myurls/domain.conf
+++ b/myurls/domain.conf
@@ -26,8 +26,14 @@ server {
     resolver 8.8.8.8 8.8.4.4 valid=60s ipv6=off;
     resolver_timeout 5s;
     add_header Strict-Transport-Security "max-age=63072000" always;
+//fixed error code 502 for long request url 
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        proxy_buffer_size 128k;
+        proxy_buffers 4 256k;
+        proxy_busy_buffers_size 256k;   
 
-    location / {
+location / {
         proxy_redirect off;
         proxy_pass http://127.0.0.1:8002;
 
@@ -42,7 +48,8 @@ server {
 
         client_max_body_size        100m;
         client_body_buffer_size     128k;
-    }
+
+}
 
     access_log /home/wwwlogs/s.ops.ci.access.log  main;
     error_log  /home/wwwlogs/s.ops.ci.error.log  warn;


### PR DESCRIPTION
增加了用于解决由于请求 URL 过长导致502 的nginx 配置。